### PR TITLE
Bug fix for Validity Check

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+1.1-3: Bug fix; in validity check for input time series
 1.1-1: Bug fixes for temperature-based threshold indices; CHANGES RESULTS.
  MAJOR CHANGES:
   - Changes code to reflect improved definition of day selection for first and last two (for a five-day window) days. Specifically, removes padding values from ends of series, and wraps the day around for each year at the edges instead of wrapping around into the next year. This changes results for both in-base and out-of-base quantiles for these days by a small amount.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: climdex.pcic
-Version: 1.1-2
-Date: 2014-10-29
+Version: 1.1-3
+Date: 2014-11-07
 Title: PCIC implementation of Climdex routines
 Author: David Bronaugh <bronaugh@uvic.ca> for the Pacific Climate Impacts
     Consortium

--- a/R/climdex.r
+++ b/R/climdex.r
@@ -291,7 +291,7 @@ check.basic.argument.validity <- function(tmax, tmin, prec, tmax.dates, tmin.dat
   check.var(tavg, tavg.dates, "tavg")
   check.var(prec, prec.dates, "prec")
 
-  if(sum(c(is.null(tmax), is.null(tmin), is.null(prec), is.null(tavg))) == 0)
+  if(all(c(is.null(tmax), is.null(tmin), is.null(prec), is.null(tavg))))
     stop("Must supply at least one variable to calculate indices upon.")
 
   if(!(length(base.range) == 2 && is.numeric(base.range)))


### PR DESCRIPTION
Hi James,
I did the bug fix in the check.basic.argument.validity function and replaced the sum(c(is.null(),...))==0 with all(c(is.null(),...)). I already checked it out locally and it worked fine. 
Kind regards,
Rebekka
