### PR TITLE
Add R-CMD-check GitHub Actions Workflow

### DIFF
--- a/.github/workflows/R-CMD-check-on-PR.yaml
+++ b/.github/workflows/R-CMD-check-on-PR.yaml
@@ -1,0 +1,51 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  pull_request:
+    types: [opened, edited, reopened]
+
+name: R-CMD-check-on-PR
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: macos-latest,   r: 'release'}
+          - {os: windows-latest, r: 'release'}
+          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,   r: 'release'}
+          - {os: ubuntu-latest,   r: 'oldrel-1'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck, any::roxygen2, any::lifecycle 
+          needs: check
+          
+      - name: Document
+        run: roxygen2::roxygenize(clean=T)
+        shell: Rscript {0}
+        
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true

--- a/.github/workflows/R-CMD-check-on-push.yaml
+++ b/.github/workflows/R-CMD-check-on-push.yaml
@@ -1,12 +1,9 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
-  push:
-    branches: ['*']
-  pull_request:
-    branches: [main, master]
+  push
 
-name: R-CMD-check
+name: R-CMD-check-on-push
 
 jobs:
   R-CMD-check:
@@ -18,8 +15,6 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macos-latest,   r: 'release'}
-          - {os: windows-latest, r: 'release'}
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,0 +1,49 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: ['*']
+  pull_request:
+    branches: [main, master]
+
+name: R-CMD-check
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: macos-latest,   r: 'release'}
+          - {os: windows-latest, r: 'release'}
+          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,   r: 'release'}
+          - {os: ubuntu-latest,   r: 'oldrel-1'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          needs: check
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -9,7 +9,34 @@ on:
 name: R-CMD-check
 
 jobs:
+   document:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - name: Install dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::roxygen2
+          needs: roxygen2
+
+      - name: Document
+        run: roxygen2::roxygenise()
+        shell: Rscript {0}
+
+          
   R-CMD-check:
+    needs: document
     runs-on: ${{ matrix.config.os }}
 
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -41,9 +41,9 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck, any::roxygen2
+          extra-packages: any::rcmdcheck, any::roxygen2, any::lifecycle 
           needs: check
-
+          
       - name: Document
         run: roxygen2::roxygenize(clean=T)
         shell: Rscript {0}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -9,7 +9,7 @@ on:
 name: R-CMD-check
 
 jobs:
-   document:
+  document:
     runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -9,34 +9,7 @@ on:
 name: R-CMD-check
 
 jobs:
-  document:
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Setup R
-        uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-
-      - name: Install dependencies
-        uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: any::roxygen2
-          needs: roxygen2
-
-      - name: Document
-        run: roxygen2::roxygenise()
-        shell: Rscript {0}
-
-          
   R-CMD-check:
-    needs: document
     runs-on: ${{ matrix.config.os }}
 
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})
@@ -68,9 +41,13 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck
+          extra-packages: any::rcmdcheck, any::roxygen2
           needs: check
 
+      - name: Document
+        run: roxygen2::roxygenize(clean=T)
+        shell: Rscript {0}
+        
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true

--- a/R/climdex.r
+++ b/R/climdex.r
@@ -316,7 +316,7 @@ check.quantile.validity <- function(quantiles, present.vars, days.in.base) {
   if(is.null(quantiles))
     return()
   
-  if(class(quantiles) != "list")
+  if(!inherits(quantiles, "list"))
     stop("Provided quantiles must be a list.")
   
   if(!all(present.vars %in% names(quantiles)))

--- a/R/climdex.r
+++ b/R/climdex.r
@@ -1896,11 +1896,12 @@ climdex.quantile <- function(x, q=c(0, 0.25, 0.5, 0.75, 1)) {
 #'
 #' @return a vector containing the running mean of bin elements of vec
 #'
-#' @example
-#' \dontrun { 
+#' @examples
+#' 
+#' \dontrun{ 
 #' running.mean(c(1, 2, 3, 4, 5, 6), 2) 
 #' }
-#' \dontrun { 
+#' \dontrun{ 
 #' running.mean(c(5, 5, 5, 5, 5), 4) 
 #' }
 running.mean <- function(vec, bin){


### PR DESCRIPTION
**Description**:
This pull request adds a new GH Actions workflow named 'R-CMD-check' to the repository. The purpose of this workflow is to automate the process of checking the package for errors, warnings, or notes. The workflow uses a modified version of a prebuilt action [check-standard](https://github.com/r-lib/actions/blob/v2/examples/check-standard.yaml) from [r-lib](https://github.com/r-lib/actions/blob/v2/README.md). It runs R CMD Check on Linux, MacOS, and Windows using the latest release of R and on R-devel. 


Addresses an issue where R CMD Check fails due to a warning produced from the comparison `(class(quantiles) != "list")`. This PR Fixes the class validation using inherits() as a more robust and idiomatic approach. 


**Changes**:
- Added a new workflow named 'R-CMD-check' in `.github/workflows/`.
- Modified the check-standard action to include a step for building the package documentation, using [roxygen2](https://cran.r-project.org/web/packages/roxygen2/).


**Testing and Verification**:
- I have tested the 'R-CMD-check' workflow, which passes following a merge with the i29 branch. 


**Questions for Reviewer**:
- Would it be preferable to test only on Ubuntu for pushes to non-main branches, and then require cross-platform tests on merge with main? 


**Resolves**: 
#29 


