### PR TITLE
 Optionally return climate indices results as a data frame including the exact timing of extreme events. 

### DIFF
--- a/.github/workflows/R-CMD-check-on-PR.yaml
+++ b/.github/workflows/R-CMD-check-on-PR.yaml
@@ -1,0 +1,51 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  pull_request:
+    types: [opened, edited, reopened]
+
+name: R-CMD-check-on-PR
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: macos-latest,   r: 'release'}
+          - {os: windows-latest, r: 'release'}
+          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,   r: 'release'}
+          - {os: ubuntu-latest,   r: 'oldrel-1'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck, any::roxygen2, any::lifecycle 
+          needs: check
+          
+      - name: Document
+        run: roxygen2::roxygenize(clean=T)
+        shell: Rscript {0}
+        
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true

--- a/.github/workflows/R-CMD-check-on-push.yaml
+++ b/.github/workflows/R-CMD-check-on-push.yaml
@@ -1,0 +1,48 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push
+
+name: R-CMD-check-on-push
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,   r: 'release'}
+          - {os: ubuntu-latest,   r: 'oldrel-1'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck, any::roxygen2, any::lifecycle 
+          needs: check
+          
+      - name: Document
+        run: roxygen2::roxygenize(clean=T)
+        shell: Rscript {0}
+        
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true

--- a/R/climdex.r
+++ b/R/climdex.r
@@ -1283,7 +1283,7 @@ get.rxnday.params <- function(ci, freq= c("monthly", "annual", "seasonal")) {
 climdex.rx1day <- function(ci, freq = c("monthly", "annual", "seasonal"), include.exact.dates = FALSE) {
   rxnday.params <- get.rxnday.params(ci, freq)
   ndays <- 1
-  return(nday.consec.prec.max(ndays = ndays, include.exact.dates = include.exact.dates, date.factor = rxnday.params$date.factor, cal = rxnday.params$cal, mask = rxnday.params$mask, daily.prec = rxnday.params$data, freq = freq))
+  return(nday.consec.prec.max(daily.prec = rxnday.params$data, date.factor = rxnday.params$date.factor, ndays = ndays, include.exact.dates = include.exact.dates,  mask = rxnday.params$mask, freq = freq, cal = rxnday.params$cal))
 }
 
 #' Monthly Maximum 5-day Consecutive Precipitation
@@ -1310,7 +1310,7 @@ climdex.rx1day <- function(ci, freq = c("monthly", "annual", "seasonal"), includ
 climdex.rx5day <- function(ci, freq = c("monthly", "annual", "seasonal"), center.mean.on.last.day = FALSE, include.exact.dates = FALSE) {
   rxnday.params <- get.rxnday.params(ci, freq)
   ndays <- 5
-  return(nday.consec.prec.max(ndays = ndays, include.exact.dates = include.exact.dates, center.mean.on.last.day = center.mean.on.last.day, date.factor = rxnday.params$date.factor, cal = rxnday.params$cal, mask = rxnday.params$mask, daily.prec = rxnday.params$data, freq = freq))
+  return(nday.consec.prec.max(daily.prec = rxnday.params$data, date.factor = rxnday.params$date.factor, ndays = ndays, center.mean.on.last.day = center.mean.on.last.day, include.exact.dates = include.exact.dates, mask = rxnday.params$mask, freq = freq, cal = rxnday.params$cal))
 }
 
 #' Simple Precpitation Intensity Index

--- a/R/climdex.r
+++ b/R/climdex.r
@@ -591,22 +591,6 @@ climdexInput.raw <- function(tmax=NULL, tmin=NULL, prec=NULL, tmax.dates=NULL, t
   classify_meteorological_season_with_year <- function(date.series) {
     month <- as.integer(format(date.series, "%m"))
     year <- as.integer(format(date.series, format = "%Y"))
-    year_for_season <- year - ifelse(month %in% c(1, 2), 1, 0)
-    
-    # Vector combining season and year
-    season_with_year <- ifelse(month %in% c(12, 1, 2), paste("Winter", year_for_season),
-                               ifelse(month %in% 3:5, paste("Spring", year_for_season),
-                                      ifelse(month %in% 6:8, paste("Summer", year_for_season),
-                                             ifelse(month %in% 9:11, paste("Fall", year_for_season), NA)
-                                      )
-                               )
-    )
-    return(season_with_year)
-  }
-  
-  classify_meteorological_season_with_year <- function(date.series) {
-    month <- as.integer(format(date.series, "%m"))
-    year <- as.integer(format(date.series, format = "%Y"))
     year_for_season <- ifelse(month %in% c(1, 2), year - 1, year)
 
     # Vector combining season and year

--- a/R/climdex.r
+++ b/R/climdex.r
@@ -1706,7 +1706,7 @@ growing.season.length <- function(daily.mean.temp, date.factor, dates, northern.
       } 
       else if (is.na(gs.end[1])) {
         start <- gs.begin[1]
-        end <- ts.len
+        end <- ts.len - 1 # Last DOY
         season.length <- ts.len - start + 1
       } 
       else {

--- a/R/climdex.r
+++ b/R/climdex.r
@@ -1747,7 +1747,8 @@ growing.season.length <- function(daily.mean.temp, date.factor, dates, northern.
         sl <- c(sl,NA)
         end <- c(end,NA)
       }
-      df <- data.frame(start,sl, end, year) 
+      df <- data.frame(start,sl, end)
+      rownames(df) <- year
       return(df)
     }
     return(growing.season)
@@ -2091,8 +2092,8 @@ spell.length.max <- function(daily.prec, date.factor, threshold, op, spells.can.
     end.pcict <- origin.pcict + (end - 1) * seconds.per.day
     
     df <- data.frame(
-      duration = max.spell * mask,
       start = format(start.pcict, "%Y-%m-%d"),
+      duration = max.spell * mask,
       end = format(end.pcict, "%Y-%m-%d")
     )
     

--- a/R/climdex.r
+++ b/R/climdex.r
@@ -662,8 +662,11 @@ climdexInput.raw <- function(tmax=NULL, tmin=NULL, prec=NULL, tmax.dates=NULL, t
   season_month_counts <- sapply(unique(date.factors$seasonal), function(season) {
     length(unique(date.factors$monthly[date.factors$seasonal == season]))
   })
-  
-  for (var in present.var.list) {
+  data.vars <- present.var.list
+  if (!is.null(namasks$seasonal$tavg)){
+    data.vars <- c(data.vars, "tavg")
+  }
+  for (var in data.vars) {
     seasonal_namasks <- namasks$seasonal[[var]]
     na_months <- unique(date.factors$monthly)[is.na(namasks$monthly[[var]])]
     seasons_of_na_months <- unique(date.factors$seasonal[date.factors$monthly %in% na_months])

--- a/R/climdex.r
+++ b/R/climdex.r
@@ -953,7 +953,7 @@ climdex.gsl <- function(ci, gsl.mode = c("GSL", "GSL_first", "GSL_max", "GSL_sum
 ymd.dates <- function(origin, cal, exact.day, val) {
   origin.pcict <- as.PCICt(origin, cal)
   seconds.per.day <- 86400
-  exact.day.pcict <- origin.pcict + (exact.day - 1) * seconds.per.day
+  exact.day.pcict <- origin.pcict + (ifelse(is.na(exact.day),1,exact.day - 1)) * seconds.per.day
   ymd <- as.PCICt(exact.day.pcict, cal = cal, format = "%Y-%m-%d")
   ymd <- format(ymd, "%Y-%m-%d")
   ymd[is.na(val)] <- NA

--- a/tests/test_exact_timing.R
+++ b/tests/test_exact_timing.R
@@ -37,7 +37,7 @@ get.data.for.idx <- function(ci, idx) {
     ci@data$tmin
   }
 }
-Are.not.all.na <- function(x,r) {
+are.not.all.na <- function(x,r) {
   checkTrue(any(!is.na(x)))
   checkTrue(any(!is.na(r)))
 }
@@ -55,6 +55,18 @@ get.n.or.x.result <- function(idx, ci.csv, freq = c("monthly", "annual", "season
   return(expected.exact.date(ci.csv, data, factor.extremes, date.factors, freq, na.mask))
 }
 
+
+is.almost.equal <- function(x, r, tolerance = 0.01) {
+  if (is.na(x) && is.na(r)) {
+    return(TRUE)
+  } else if (is.na(x) || is.na(r)) {
+    return(FALSE)
+  } else {
+    return(abs(x - r) < tolerance)
+  }
+}
+
+
 # Test for TXx, TNn, TNx and TXn indices
 climdex.pcic.test.exact.date.n.or.x.indices <- function() {
   test.indices <- c("txx", "tnn", "tnx", "txn")
@@ -68,15 +80,16 @@ climdex.pcic.test.exact.date.n.or.x.indices <- function() {
       result <- do.call(fun, list(ci.csv, freq = freq, include.exact.dates = TRUE))
       expected <- get.n.or.x.result(idx, ci.csv, freq)
       result$ymd <- as.character(result$ymd)
-      checkIdentical(length(expected), length(result$ymd), paste("Lengths differ expected:", length(expected),"climdex result:", length(result$ymd)))
-      Are.not.all.na(expected, result$ymd)
+      checkIdentical(length(expected), nrow(result), paste("Lengths differ. Expected:", length(expected),"Result:", nrow(result)))
+      are.not.all.na(expected, result$ymd)
        for (i in seq_along(expected)) {
         expected.val <- data[ci.csv@dates %in% as.character(expected[[i]])]
         expected.val <- ifelse(length(expected.val) == 0, NA, expected.val)
         checkIdentical(as.character(expected[[i]]), as.character(result$ymd[i]), 
-                       paste("idx:", idx, "Expected: ", as.character(expected[[i]]), "result: ", as.character(result$ymd[i])))
-        checkTrue(all.equal(as.numeric(expected.val), as.numeric(result$val[i]), tolerance = 0.01), 
-                  msg = paste("idx:", idx, "Expected: ", as.character(expected.val), "result: ", as.character(result$val[i])))
+                       paste("Idx:", idx, "Expected: ", as.character(expected[[i]]), "Result: ", as.character(result$ymd[i])))
+        checkTrue(is.almost.equal(as.numeric(expected.val), as.numeric(result$val[i])), 
+                  msg = paste("Idx:", idx, "Expected: ", as.numeric(expected.val), "Result: ", as.numeric(result$val[i])))
+        
       }
     }
   }
@@ -102,14 +115,14 @@ climdex.pcic.test.n.or.x.dates.at.end.of.year <- function() {
       result <- do.call(fun, list(ci.nx.eoy, freq = freq, include.exact.dates = TRUE))
       expected <- get.n.or.x.result(idx, ci.nx.eoy, freq)
       result$ymd <- as.character(result$ymd)
-      checkIdentical(length(expected), length(result$ymd), paste("Lengths differ expected:", length(result),"climdex result:", length(result)))
-      Are.not.all.na(expected, result$ymd)
+      checkIdentical(length(expected), nrow(result), paste("Lengths differ. Expected:", length(expected),"Result:", nrow(result)))
+      are.not.all.na(expected, result$ymd)
       for (i in seq_along(expected)) {
         expected.val <- data[ci.nx.eoy@dates %in% as.character(expected[[i]])]
         expected.val <- ifelse(length(expected.val) == 0, NA, expected.val)
-        checkIdentical(as.character(expected[[i]]), result$ymd[i], paste("idx:", idx, "Expected: ", as.character(expected[[i]]), "result: ", as.character(result$ymd[i])))
-        checkTrue(all.equal(as.numeric(expected.val), as.numeric(result$val[i]), tolerance = 0.01), 
-                  msg = paste("idx:", idx, "Expected: ", as.character(expected.val), "result: ", as.character(result$val[i])))
+        checkIdentical(as.character(expected[[i]]), result$ymd[i], paste("idx:", idx, "Expected: ", as.character(expected[[i]]), "Result: ", as.character(result$ymd[i])))
+        checkTrue(is.almost.equal(as.numeric(expected.val), as.numeric(result$val[i])), 
+                  msg = paste("Idx:", idx, "Expected: ", as.numeric(expected.val), "Result: ", as.numeric(result$val[i])))
       }
     }
   }
@@ -151,8 +164,8 @@ climdex.pcic.test.exact.date.rxnd.indices <- function() {
       center.mean.on.last.day <- FALSE
       expected <- get.Rxnday.result(idx, ci.csv, freq, ndays, center.mean.on.last.day)
       result$ymd <- as.character(result$ymd)
-      checkIdentical(length(expected), length(result$ymd), paste("Lengths differ expected:", length(expected),"climdex result:", length(result$ymd)))
-      Are.not.all.na(expected, result$ymd)
+      checkIdentical(length(expected), nrow(result), paste("Lengths Differ. Expected:", length(expected),"Result:", nrow(result)))
+      are.not.all.na(expected, result$ymd)
       for (i in seq_along(result$ymd)) {
         if (!is.na(result$ymd[i])) {
           if (ndays == 5) {
@@ -168,9 +181,9 @@ climdex.pcic.test.exact.date.rxnd.indices <- function() {
         }
 
 
-        checkIdentical(as.character(expected[[i]]), result$ymd[i], paste("idx:", idx, "Expected: ", as.character(expected[[i]]), "result: ", as.character(result$ymd[i])))
-        checkTrue(all.equal(as.numeric(expected.val), as.numeric(result$val[i]), tolerance = 0.01), 
-                  msg = paste("idx:", idx, "Expected: ", as.character(expected.val), "result: ", as.character(result$val[i])))
+        checkIdentical(as.character(expected[[i]]), result$ymd[i], paste("idx:", idx, "Expected: ", as.character(expected[[i]]), "Result: ", as.character(result$ymd[i])))
+        checkTrue(is.almost.equal(as.numeric(expected.val), as.numeric(result$val[i])), 
+                  msg = paste("Idx:", idx, "Expected: ", as.numeric(expected.val), "Result: ", as.numeric(result$val[i])))
       }
     }
   }
@@ -186,8 +199,8 @@ climdex.pcic.test.rx5d.center.mean.on.last.day <- function() {
     result <- do.call(fun, list(ci.csv, freq = freq, center.mean.on.last.day = center.mean.on.last.day, include.exact.dates = TRUE))
     expected <- get.Rxnday.result(idx, ci.csv, freq, ndays, center.mean.on.last.day)
     result$ymd <- as.character(result$ymd)
-    checkIdentical(length(expected), length(result$ymd), paste("Lengths differ expected:", length(expected),"climdex result:", length(result$ymd)))
-    Are.not.all.na(expected, result$ymd)
+    checkIdentical(length(expected), nrow(result), paste("Lengths differ. Expected:", length(expected),"Result:", nrow(result)))
+    are.not.all.na(expected, result$ymd)
     for (i in seq_along(result$ymd)) {
       if (!is.na(result$ymd[i])) {
         if (ndays == 5) {
@@ -209,9 +222,9 @@ climdex.pcic.test.rx5d.center.mean.on.last.day <- function() {
       }
       
       
-      checkIdentical(as.character(expected[[i]]), result$ymd[i], paste("idx:", idx, "Expected: ", as.character(expected[[i]]), "result: ", as.character(result$ymd[i])))
-      checkTrue(all.equal(as.numeric(expected.val), as.numeric(result$val[i]), tolerance = 0.01), 
-                msg = paste("idx:", idx, "Expected: ", as.character(expected.val), "result: ", as.character(result$val[i])))
+      checkIdentical(as.character(expected[[i]]), result$ymd[i], paste("Idx:", idx, "Expected: ", as.character(expected[[i]]), "Result: ", as.character(result$ymd[i])))
+      checkTrue(is.almost.equal(as.numeric(expected.val), as.numeric(result$val[i])), 
+                msg = paste("Idx:", idx, "Expected: ", as.numeric(expected.val), "Result: ", as.numeric(result$val[i])))
     }
   }
 }
@@ -257,21 +270,24 @@ get.spell.bounds <- function(ci, idx) {
 
     return(spell.bounds)
   })
-  return(spell.boundary)
+  return(do.call(rbind, spell.boundary))
 }
 # Generic to compare the expected and climdex-calculated results for the spell tests.
 check.spell.results <- function(expected, result, idx) {
-  checkIdentical(length(expected), length(result$start), paste("Lengths differ expected:", length(expected),"climdex result:", length(result$start)))
-  checkIdentical(length(expected), length(result$end), paste("Lengths differ expected:", length(expected),"climdex result:", length(result$end)))
+  checkIdentical(nrow(expected), nrow(result), paste("Lengths Differ. Expected:", nrow(expected), "Result:", nrow(result)))
+  
   for (i in seq_along(result$start)) {
-    if (is.na(expected[[i]]$duration)) {
-      expected[[i]]$start <- NA
-      expected[[i]]$end <- NA
+    if (is.na(expected$duration[i])) {
+      expected$start[i] <- NA
+      expected$end[i] <- NA
     }
-    checkIdentical(as.character(expected[[i]]$start), result$start[i], paste("Start of spells for index: ", idx, " do not agree: Expected:", as.character(expected[[i]]$start), " Result: ", result$start[i]))
-    checkIdentical(as.character(expected[[i]]$end), result$end[i])
+    checkIdentical(as.character(expected$start[i]), result$start[i], paste("Start of spells for index:", idx, "do not agree. Expected:", as.character(expected$start[i]), "Result:", result$start[i]))
+    checkIdentical(as.character(expected$end[i]), result$end[i], paste("End of spells for index:", idx, "do not agree. Expected:", as.character(expected$end[i]), "Result:", result$end[i]))
+    checkTrue(is.almost.equal(as.numeric(expected$duration[i]), as.numeric(result$duration[i])), 
+              msg = paste("Idx:", idx, "Expected:", as.numeric(expected$duration[i]), "Result:", as.numeric(result$duration[i])))
   }
 }
+
 
 # Test cdd and cwd spells with example data set.
 climdex.pcic.test.spell.boundaries <- function() {
@@ -284,8 +300,8 @@ climdex.pcic.test.spell.boundaries <- function() {
     }
 
     expected <- get.spell.bounds(ci.csv, idx)
-    Are.not.all.na(expected, result$start)
-    Are.not.all.na(expected, result$end)
+    are.not.all.na(expected$start, result$start)
+    are.not.all.na(expected$end, result$end)
     check.spell.results(expected, result, idx)
   }
 }
@@ -338,6 +354,12 @@ climdex.pcic.test.no.spell <- function() {
 
     expected <- get.spell.bounds(ci, idx)
     check.spell.results(expected, result, idx)
+    
+    checkTrue(all(is.na(expected$start)))
+    checkTrue(all(is.na(result$start)))
+    checkTrue(all(is.na(expected$end)))
+    checkTrue(all(is.na(result$end)))
+
   }
 }
 
@@ -468,10 +490,10 @@ expected.gsl <- function(ci, include.exact.dates) {
       duration <- 0
     } else if (is.na(end.idx)) {
       end.result <- gsl.test.ymd(year, cal, length(tavg)-1, n.h)
-      duration <- length(tavg) + 1 - start.idx
+      duration <- length(tavg)  - start.idx + 1
     } else {
       end.result <- gsl.test.ymd(year, cal, (ifelse(end.idx > 1, midpoint + end.idx - 1, ifelse(!n.h && next.year.is.leap, midpoint, midpoint + 1))), n.h)
-      duration <- (midpoint + end.idx) - start.idx
+      duration <- difftime(as.Date(end.result),as.Date(start.result))
     }
 
     list(start = start.result, end = end.result, duration = duration)
@@ -517,8 +539,8 @@ expected.gsl <- function(ci, include.exact.dates) {
 test_gsl <- function(ci, test_name) {
   expected <- expected.gsl(ci, include.exact.dates = TRUE)
   result <- climdex.gsl(ci, "GSL", include.exact.dates = TRUE)
-  checkIdentical(length(expected$start), length(result$start), paste("Lengths differ expected:", length(expected$start),"climdex result:", length(result$start)))
-  checkIdentical(length(expected$end), length(result$end), paste("Lengths differ expected:", length(expected),"climdex result:", length(result$end)))
+  checkIdentical(length(expected$start), length(result$start), paste("Lengths differ. Expected:", length(expected$start),"Result:", length(result$start)))
+  checkIdentical(length(expected$end), length(result$end), paste("Lengths differ. Expected:", length(expected),"Result:", length(result$end)))
   
   for (i in seq_along(result$start)) {
     if (test_name == "climdex.pcic.test.na.masks.gsl") {
@@ -528,11 +550,13 @@ test_gsl <- function(ci, test_name) {
       }
     }
     if (test_name != "climdex.pcic.test.no.gsl"){
-      Are.not.all.na(expected$start, result$start)
-      Are.not.all.na(expected$end, result$end)
+      are.not.all.na(expected$start, result$start)
+      are.not.all.na(expected$end, result$end)
     }
-    checkIdentical(expected$start[i], result$start[i], paste("Start of GSL does not match Expected:", as.character(expected$start[i]), " Result: ", result$start[i], " (", test_name, ")"))
-    checkIdentical(expected$end[i], result$end[i], paste("End of GSL does not match Expected:", as.character(expected$end[i]), " Result: ", result$end[i], " (", test_name, ")"))
+    checkIdentical(expected$start[i], result$start[i], paste("Start of GSL does not match. Expected:", as.character(expected$start[i]), " Result: ", result$start[i], " (", test_name, ")"))
+    checkIdentical(expected$end[i], result$end[i], paste("End of GSL does not match. Expected:", as.character(expected$end[i]), " Result: ", result$end[i], " (", test_name, ")"))
+    checkTrue(is.almost.equal(as.numeric(expected$sl[i]), as.numeric(result$sl[i])), 
+              msg = paste("Idx:GSL\n Year:",rownames(result)[i],"\n Expected: ", as.numeric(expected$sl[i]), "Result: ", as.numeric(result$sl[i])))
   }
 }
 

--- a/tests/test_exact_timing.R
+++ b/tests/test_exact_timing.R
@@ -803,46 +803,6 @@ climdex.pcic.test.consistent.indices.return.types <- function() {
   result.n.d <- climdex.gsl(ci.types.test,"GSL", include.exact.dates = F)
   checkTypes(result.e.d$sl, result.n.d)
 }
-# 
-# climdex.pcic.test.indicies.on.random.datasets <- function(){
-#   for (i in 1:5000){
-#     cal <- 365
-#     test.dates <- seq(as.PCICt("1961-01-01", cal = cal), as.PCICt("1967-12-31", cal = cal), by = "days")
-#     test.prec.ran <- c(sample(0:2, length(test.dates), replace = TRUE))
-#     test.tmin.ran <- c(sample(-10:32, length(test.dates), replace = TRUE))
-#     test.tmax.ran <- c(sample(-10:32, length(test.dates), replace = TRUE))
-# 
-# 
-#     years <- format(test.dates, "%Y")
-#     unique.years <- unique(years)
-#     for (year in unique.years) {
-#       year.indices <- which(years == year)
-#       na.indices <- sample(year.indices, sample(1:7, 1))
-#       test.prec.ran[na.indices] <- NA
-#       test.tmin.ran[na.indices] <- NA
-#       test.tmax.ran[na.indices] <- NA
-#     }
-# 
-# 
-#     ci.ran <- climdexInput.raw(tmin =test.tmin.ran, tmax = test.tmax.ran, prec = test.prec.ran, tmin.dates=test.dates, tmax.dates = test.dates, prec.dates = test.dates)
-# 
-#     test.indices <- names(climdex.min.max.idx.list)
-#     for(idx in test.indices){
-#       fun <- paste("climdex", idx, sep = ".")
-#       date.factors <- c("annual", "monthly", "seasonal")
-#       for (freq in date.factors) {
-#         do.call(fun, list(ci.ran, freq = freq, include.exact.dates = TRUE))
-# 
-#       }
-#     }
-# 
-#     freq<- "annual"
-#     climdex.cdd(ci.ran, spells.can.span.years = F, include.exact.dates = TRUE)
-#     climdex.cwd(ci.ran, spells.can.span.years = F, include.exact.dates = TRUE)
-#     climdex.gsl(ci.ran,"GSL", include.exact.dates = TRUE)
-#   }
-# 
-# 
-# }
+
 
 

--- a/tests/test_exact_timing.R
+++ b/tests/test_exact_timing.R
@@ -2,7 +2,6 @@ library(climdex.pcic)
 library(RUnit)
 
 # Setup
-
 wd <- "./"
 source("../../climdex.pcic/R/climdex.r")
 
@@ -13,7 +12,7 @@ ClimVars.prec <- file.path(wd, "1018935_ONE_DAY_PRECIPITATION.csv")
 
 datacol <- list(tmax = "MAX_TEMP", tmin = "MIN_TEMP", prec = "ONE_DAY_PRECIPITATION")
 ci.csv <- climdexInput.csv(ClimVars.tmax, ClimVars.tmin, ClimVars.prec, data.columns = datacol, base.range = c(1981, 1990))
-ci.csv.sh <- climdexInput.csv(ClimVars.tmax, ClimVars.tmin, ClimVars.prec, data.columns = datacol, base.range = c(1981, 1990),northern.hemisphere = F)
+ci.csv.sh <- climdexInput.csv(ClimVars.tmax, ClimVars.tmin, ClimVars.prec, data.columns = datacol, base.range = c(1981, 1990), northern.hemisphere = F)
 
 expected.result <- function(ci.csv, data, date.index, date.factors, freq, fun, offset, na.mask) {
   ex.r <- c()
@@ -53,14 +52,14 @@ get.n.or.x.result <- function(idx, ci.csv, freq = c("monthly", "annual", "season
 climdex.pcic.test.exact.date.n.or.x.indices <- function() {
   test.indices <- c("txx", "tnn", "tnx", "txn")
   date.factors <- c("annual", "monthly", "seasonal")
-  
+
   for (idx in test.indices) {
     data <- if (substr(idx, 2, 2) == "x") {
       ci.csv@data$tmax
     } else {
       ci.csv@data$tmin
     }
-    
+
     for (freq in date.factors) {
       print(paste(idx, freq))
       fun <- paste("climdex", idx, sep = ".")
@@ -86,7 +85,7 @@ get.Rxnday.result <- function(idx, ci.csv, freq = c("monthly", "annual", "season
     data[is.na(data)] <- 0
     prec.runsum <- running.mean(data, ndays)
     prec.runsum[is.na(prec.runsum)] <- 0
-    
+
     if (center.mean.on.last.day) {
       k2 <- ndays %/% 2
       prec.runsum <- c(rep(0, k2), prec.runsum[1:(length(prec.runsum) - k2)])
@@ -102,7 +101,7 @@ get.Rxnday.result <- function(idx, ci.csv, freq = c("monthly", "annual", "season
 climdex.pcic.test.exact.date.rxnd.indices <- function() {
   test.indices <- c("rx1day", "rx5day")
   date.factors <- c("annual", "monthly", "seasonal")
-  
+
   for (idx in test.indices) {
     for (freq in date.factors) {
       print(paste(idx, freq))
@@ -112,7 +111,7 @@ climdex.pcic.test.exact.date.rxnd.indices <- function() {
       center.mean.on.last.day <- FALSE
       expected <- get.Rxnday.result(idx, ci.csv, freq, ndays, center.mean.on.last.day)
       result$ymd <- as.character(result$ymd)
-      
+
       for (i in seq_along(result$ymd)) {
         if (!is.na(result$ymd[i])) {
           if (ndays == 5) {
@@ -133,9 +132,10 @@ climdex.pcic.test.exact.date.rxnd.indices <- function() {
   }
 }
 
+
 find.longest.consecutive.true <- function(bool.array) {
   max.length <- current.length <- start.index <- max.start.index <- 0
-  
+
   for (i in seq_along(bool.array)) {
     if (!is.na(bool.array[i]) && bool.array[i]) {
       current.length <- current.length + 1
@@ -150,7 +150,7 @@ find.longest.consecutive.true <- function(bool.array) {
       start.index <- current.length <- 0
     }
   }
-  
+
   data.frame(start = max.start.index, end = max.start.index + max.length - 1, duration = max.length)
 }
 
@@ -169,7 +169,7 @@ get.spell.bounds <- function(ci, idx) {
     } else {
       spell.bounds <- data.frame(start = NA, end = NA, duration = 0)
     }
-    
+
     return(spell.bounds)
   })
   return(spell.boundary)
@@ -191,13 +191,13 @@ climdex.pcic.test.spell.boundaries <- function() {
   test.indices <- c("cdd", "cwd")
   for (idx in test.indices) {
     print(paste(idx))
-    
+
     if (idx == "cdd") {
       result <- climdex.cdd(ci.csv, spells.can.span.years = F, as.df = TRUE)
     } else {
       result <- climdex.cwd(ci.csv, spells.can.span.years = F, as.df = TRUE)
     }
-    
+
     expected <- get.spell.bounds(ci.csv, idx)
     check.spell.results(expected, result, idx)
   }
@@ -210,14 +210,14 @@ climdex.pcic.test.multi.year.spell <- function() {
 
   test.prec.data.dry <- rep(0, length(test.dates))
   ci.dry <- climdexInput.raw(prec = test.prec.data.dry, prec.dates = test.dates)
-  
+
   test.prec.data.wet <- rep(2, length(test.dates))
   ci.wet <- climdexInput.raw(prec = test.prec.data.wet, prec.dates = test.dates)
-  
+
   test.indices <- c("cdd", "cwd")
   for (idx in test.indices) {
     print(paste(idx))
-    
+
     if (idx == "cdd") {
       result <- climdex.cdd(ci.dry, spells.can.span.years = F, as.df = TRUE)
       ci <- ci.dry
@@ -225,25 +225,26 @@ climdex.pcic.test.multi.year.spell <- function() {
       result <- climdex.cwd(ci.wet, spells.can.span.years = F, as.df = TRUE)
       ci <- ci.wet
     }
-    
+
     expected <- get.spell.bounds(ci, idx)
     check.spell.results(expected, result, idx)
   }
 }
+
 
 climdex.pcic.test.no.spell <- function() {
   cal <- 365
   test.dates <- seq(as.PCICt("1961-01-01", cal = cal), as.PCICt("1967-12-31", cal = cal), by = "days")
   test.prec.data.dry <- rep(0, length(test.dates))
   test.prec.data.wet <- rep(1, length(test.dates))
-  
+
   ci.wet <- climdexInput.raw(prec = test.prec.data.wet, prec.dates = test.dates)
   ci.dry <- climdexInput.raw(prec = test.prec.data.dry, prec.dates = test.dates)
-  
+
   test.indices <- c("cdd", "cwd")
   for (idx in test.indices) {
     print(paste(idx))
-    
+
     if (idx == "cdd") {
       result <- climdex.cdd(ci.wet, spells.can.span.years = F, as.df = TRUE)
       ci <- ci.wet
@@ -251,11 +252,12 @@ climdex.pcic.test.no.spell <- function() {
       result <- climdex.cwd(ci.dry, spells.can.span.years = F, as.df = TRUE)
       ci <- ci.dry
     }
-    
+
     expected <- get.spell.bounds(ci, idx)
     check.spell.results(expected, result, idx)
   }
 }
+
 
 climdex.pcic.test.na.masks.spell <- function() {
   cal <- 365
@@ -264,11 +266,11 @@ climdex.pcic.test.na.masks.spell <- function() {
   test.prec.data.ran <- c(sample(0:2, length(test.dates), replace = TRUE))
   ci.ran <- climdexInput.raw(prec = test.prec.data.ran, prec.dates = test.dates)
   ci.ran@namasks$annual$prec <- rep(c(NA, 1), length.out = length(unique(test.dates.factor)))
-  
+
   test.indices <- c("cdd", "cwd")
   for (idx in test.indices) {
     print(paste(idx))
-    
+
     if (idx == "cdd") {
       result <- climdex.cdd(ci.ran, spells.can.span.years = F, as.df = TRUE)
     } else {
@@ -277,4 +279,144 @@ climdex.pcic.test.na.masks.spell <- function() {
     expected <- get.spell.bounds(ci.ran, idx)
     check.spell.results(expected, result, idx)
   }
+}
+
+
+gsl.test.ymd <- function(year, cal, doy, northern.hemisphere) {
+  origin <- ifelse(northern.hemisphere, paste(year, "01", "01", sep = "-"), paste(year, "07", "01", sep = "-"))
+  origin.pcict <- as.PCICt(origin, cal)
+  seconds.per.day <- 86400
+  doy.pcict <- origin.pcict + (doy - 1) * seconds.per.day
+  ymd <- as.PCICt(doy.pcict, cal = cal, format = "%Y-%m-%d")
+  return(format(ymd, "%Y-%m-%d"))
+}
+
+
+find.repeated <- function(tavg, repetition, op) {
+  count <- 0
+  index <- 0
+  set.flag <- F
+  for (i in seq_along(tavg)) {
+    if (!is.na(tavg[i])) {
+      if ((op == ">" && tavg[i] > 5) || (op == "<" && tavg[i] < 5)) {
+        count <- count + 1
+      } else {
+        count <- 0
+      }
+
+      if (count >= repetition) {
+        index <- i - repetition + 1
+        set.flag <- T
+        break
+      }
+    } else {
+      count <- 0
+    }
+  }
+  if (set.flag) {
+    return(index)
+  } else {
+    return(NA)
+  }
+}
+
+
+expected.gsl <- function(ci, as.df) {
+  cal <- attr(ci@dates, "cal")
+  n.h <- ci@northern.hemisphere
+  gsl.output <- lapply(unique(ci@date.factors$annual), function(year) {
+    year.length <- length(ci@dates[ci@date.factors$annual == year])
+    year.idx <- ci@date.factors$annual == year
+
+    if (!n.h) {
+      sy <- paste(year, "07", "01", sep = "-")
+      sy.pcict <- as.PCICt(sy, cal)
+      seconds.per.day <- 86400
+      ey.pcict <- sy.pcict + year.length * seconds.per.day
+      date_indices <- which(ci@dates >= sy.pcict & ci@dates < ey.pcict)
+      tavg <- ci@data$tavg[date_indices]
+    } else {
+      tavg <- ci@data$tavg[year.idx]
+    }
+
+    midpoint <- length(tavg) %/% 2
+    first.half <- tavg[1:midpoint - 1]
+    second.half <- tavg[(midpoint):length(tavg)]
+    op.gt <- ">"
+    op.lt <- "<"
+
+    start.idx <- find.repeated(first.half, 6, op.gt)
+    end.idx <- find.repeated(second.half, 6, op.lt) - 1
+    start.result <- gsl.test.ymd(year, cal, start.idx, n.h)
+
+    if (is.na(start.idx)) {
+      start.result <- NA_character_
+      end.result <- NA_character_
+      duration <- 0
+    } else if (is.na(end.idx)) {
+      end.result <- gsl.test.ymd(year, cal, length(tavg) + 1, n.h)
+      duration <- length(tavg) + 1 - start.idx
+    } else {
+      end.result <- gsl.test.ymd(year, cal, midpoint + end.idx, n.h)
+      duration <- midpoint + end.idx - start.idx
+    }
+    list(start = start.result, end = end.result, duration = duration)
+  })
+
+  starts <- lapply(gsl.output, `[[`, "start")
+  ends <- lapply(gsl.output, `[[`, "end")
+  season <- lapply(gsl.output, `[[`, "duration")
+
+  if (as.df) {
+    ex.r <- data.frame(start = unlist(starts), end = unlist(ends), sl = unlist(season))
+    if (!n.h) ci@namasks$annual$tavg[length(ci@namasks$annual$tavg)] <- NA
+    ex.r$sl <- ex.r$sl * ci@namasks$annual$tavg
+    ex.r$start[is.na(ex.r$sl)] <- NA
+    ex.r$end[is.na(ex.r$sl)] <- NA
+  }
+  return(ex.r)
+}
+
+# Generic GSL test function
+test_gsl <- function(ci, test_name) {
+  expected <- expected.gsl(ci, as.df = TRUE)
+  result <- climdex.gsl(ci, "GSL", as.df = TRUE)
+
+  for (i in seq_along(result$start)) {
+    checkIdentical(expected$start[i], result$start[i], paste("Start of GSL does not match Expected:", as.character(expected$start[i]), " Result: ", result$start[i], " (", test_name, ")"))
+    checkIdentical(expected$end[i], result$end[i], paste("End of GSL does not match Expected:", as.character(expected$end[i]), " Result: ", result$end[i], " (", test_name, ")"))
+  }
+}
+
+climdex.pcic.test.gsl <- function() {
+  test_gsl(ci.csv, "climdex.pcic.test.gsl")
+}
+
+
+climdex.pcic.test.multi.year.gsl <- function() {
+  cal <- 365
+  test.dates <- seq(as.PCICt("1961-01-01", cal = cal), as.PCICt("1967-12-31", cal = cal), by = "days")
+  test.tavg.data <- c(rep(4, cal - 15), rep(6, length(test.dates) - (cal - 15)))
+  ci.gsl <- climdexInput.raw(tavg = test.tavg.data, tavg.dates = test.dates)
+  test_gsl(ci.gsl, "climdex.pcic.test.multi.year.gsl")
+}
+
+
+climdex.pcic.test.no.gsl <- function() {
+  cal <- 365
+  test.dates <- seq(as.PCICt("1961-01-01", cal = cal), as.PCICt("1964-12-31", cal = cal), by = "days")
+  test.tavg.data <- c(rep(4, length(test.dates)))
+  ci.gsl <- climdexInput.raw(tavg = test.tavg.data, tavg.dates = test.dates)
+  test_gsl(ci.gsl, "climdex.pcic.test.no.gsl")
+}
+
+
+climdex.pcic.test.na.masks.gsl <- function() {
+  cal <- 365
+  test.dates <- seq(as.PCICt("1961-01-01", cal = cal), as.PCICt("1969-12-31", cal = cal), by = "days")
+  test.dates.factor <- factor(format(test.dates, "%Y"))
+  test.tavg.data <- c(sample(1:10, length(test.dates), replace = TRUE))
+  ci.gsl <- climdexInput.raw(tavg = test.tavg.data, tavg.dates = test.dates)
+  ci.gsl@namasks$annual$tavg <- rep(c(NA, 1), length.out = length(unique(test.dates.factor)))
+  test_gsl(ci.gsl, "climdex.pcic.test.na.masks.gsl")
 }

--- a/tests/test_exact_timing.R
+++ b/tests/test_exact_timing.R
@@ -37,6 +37,7 @@ get.data.for.idx <- function(ci, idx) {
     ci@data$tmin
   }
 }
+
 are.not.all.na <- function(x,r) {
   checkTrue(any(!is.na(x)))
   checkTrue(any(!is.na(r)))
@@ -55,7 +56,7 @@ get.n.or.x.result <- function(idx, ci.csv, freq = c("monthly", "annual", "season
   return(expected.exact.date(ci.csv, data, factor.extremes, date.factors, freq, na.mask))
 }
 
-
+#Custom checkEqual to compare expected and climdex results.
 is.almost.equal <- function(x, r, tolerance = 0.01) {
   if (is.na(x) && is.na(r)) {
     return(TRUE)
@@ -67,7 +68,7 @@ is.almost.equal <- function(x, r, tolerance = 0.01) {
 }
 
 
-# Test for TXx, TNn, TNx and TXn indices
+# Test for TXx, TNn, TNx and TXn indices.
 climdex.pcic.test.exact.date.n.or.x.indices <- function() {
   test.indices <- c("txx", "tnn", "tnx", "txn")
   date.factors <- c("annual", "monthly", "seasonal")
@@ -128,6 +129,7 @@ climdex.pcic.test.n.or.x.dates.at.end.of.year <- function() {
   }
 }
 
+# Check extreme dates in winter season.
 climdex.pcic.test.n.or.x.dates.for.winter.season <- function() {
   test.indices <- c("txx", "tnn", "tnx", "txn")
   cal <- 365
@@ -220,7 +222,7 @@ climdex.pcic.test.exact.date.rxnd.indices <- function() {
     }
   }
 }
-
+# Check that rx5day works with the mean centered on the last day of the window.
 climdex.pcic.test.rx5d.center.mean.on.last.day <- function() {
   date.factors <- c("annual", "monthly", "seasonal")
   ndays <- 5 
@@ -444,7 +446,7 @@ climdex.pcic.test.na.masks.spell <- function() {
     check.spell.results(expected, result, idx)
   }
 }
-
+# Check that the start of the (only) spell for 1962 starts in 1961.
 climdex.pcic.test.spells.can.span.years <- function() {
   test.indices <- c("cdd", "cwd")
   cal <- 365
@@ -473,6 +475,7 @@ climdex.pcic.test.spells.can.span.years <- function() {
   }
 }
 
+# Edge case for different year lengths.
 climdex.pcic.test.spells.can.span.leap.year <- function() {
   test.indices <- c("cdd", "cwd")
   cal <- "proleptic_gregorian"
@@ -695,7 +698,7 @@ climdex.pcic.test.gsl.southern.hemisphere <- function() {
   test.gsl(ci.csv.sh, "climdex.pcic.test.gsl.southern.hemisphere")
 }
 
-
+# Get the season from the year and month of an exact date.
 format.seasons <- function(months, years) {
   ifelse(months %in% c(12, 1, 2), paste("Winter", as.integer(years) - ifelse(months %in% c(1, 2), 1, 0)),
          ifelse(months %in% 3:5, paste("Spring", years),
@@ -705,7 +708,7 @@ format.seasons <- function(months, years) {
          )
   )
 }
-
+# Check that each day in results are in the correct year, month or season.
 check.single.day.in.factors <- function(freq, result) {
   non.na.rows <- !is.na(result$ymd)
   result.formatted <- switch(
@@ -722,7 +725,7 @@ check.single.day.in.factors <- function(freq, result) {
 }
 
 
-
+# Check that all the bounds of a spell, when spells cannot span years are contained within the bounds of a date factor. 
 check.duration.bounds.in.factors <- function(freq, result, spells.can.span.years = F, is.gsl = F) {
   non.na.starts <- !is.na(result$start)
   non.na.ends <- !is.na(result$end)
@@ -735,7 +738,7 @@ check.duration.bounds.in.factors <- function(freq, result, spells.can.span.years
 
 }
 
-
+# Test that the exact dates for all indices except for GSL have exact dates returned are in their associated date factor.
 climdex.pcic.tests.exact.dates.are.in.factors <- function() {
   test.indices <- c("txx", "tnn", "tnx", "txn", "rx1day", "rx5day")
   for(idx in test.indices){

--- a/tests/test_exact_timing.R
+++ b/tests/test_exact_timing.R
@@ -83,7 +83,7 @@ climdex.pcic.test.exact.date.n.or.x.indices <- function() {
       checkIdentical(length(expected), nrow(result), paste("Lengths differ. Expected:", length(expected),"Result:", nrow(result)))
       are.not.all.na(expected, result$ymd)
        for (i in seq_along(expected)) {
-        expected.val <- data[ci.csv@dates %in% as.character(expected[[i]])]
+        expected.val <- data[ci.csv@dates == expected[[i]]]
         expected.val <- ifelse(length(expected.val) == 0, NA, expected.val)
         checkIdentical(as.character(expected[[i]]), as.character(result$ymd[i]), 
                        paste("Idx:", idx, "Expected: ", as.character(expected[[i]]), "Result: ", as.character(result$ymd[i])))
@@ -118,7 +118,7 @@ climdex.pcic.test.n.or.x.dates.at.end.of.year <- function() {
       checkIdentical(length(expected), nrow(result), paste("Lengths differ. Expected:", length(expected),"Result:", nrow(result)))
       are.not.all.na(expected, result$ymd)
       for (i in seq_along(expected)) {
-        expected.val <- data[ci.nx.eoy@dates %in% as.character(expected[[i]])]
+        expected.val <- data[ci.nx.eoy@dates == expected[[i]]]
         expected.val <- ifelse(length(expected.val) == 0, NA, expected.val)
         checkIdentical(as.character(expected[[i]]), result$ymd[i], paste("idx:", idx, "Expected: ", as.character(expected[[i]]), "Result: ", as.character(result$ymd[i])))
         checkTrue(is.almost.equal(as.numeric(expected.val), as.numeric(result$val[i])), 

--- a/tests/test_exact_timing.R
+++ b/tests/test_exact_timing.R
@@ -120,6 +120,7 @@ climdex.pcic.test.exact.date.rxnd.indices <- function() {
         } else {
           expected.value <- NA
           checkTrue(is.na(expected[[i]]) && is.na(result$val[i]))
+          next
         }
         checkEqualsNumeric(as.numeric(expected.value), as.numeric(result$val[i]), tolerance = 0.01)
         checkIdentical(as.character(expected[[i]]), result$ymd[i])

--- a/tests/test_exact_timing.R
+++ b/tests/test_exact_timing.R
@@ -69,7 +69,7 @@ climdex.pcic.test.exact.date.n.or.x.indices <- function() {
         expected.val <- data[ci.csv@dates %in% as.character(expected[[i]])]
         expected.val <- ifelse(length(expected.val) == 0, NA, expected.val)
         checkIdentical(as.character(expected[[i]]), as.character(result$ymd[i]), paste("idx:", idx, "Expected: ", as.character(expected[[i]]), "result: ", as.character(result$ymd[i])))
-        checkEqualsNumeric(as.numeric(expected.val), as.numeric(result$val[i]))
+        checkIdentical(as.numeric(expected.val), as.numeric(result$val[i]))
       }
     }
   }
@@ -99,7 +99,7 @@ climdex.pcic.test.n.or.x.dates.at.end.of.year <- function() {
         expected.val <- data[ci.nx.eoy@dates %in% as.character(expected[[i]])]
         expected.val <- ifelse(length(expected.val) == 0, NA, expected.val)
         checkIdentical(as.character(expected[[i]]), result$ymd[i])
-        checkEqualsNumeric(as.numeric(expected.val), as.numeric(result$val[i]))
+        checkIdentical(as.numeric(expected.val), as.numeric(result$val[i]))
       }
     }
   }
@@ -156,8 +156,9 @@ climdex.pcic.test.exact.date.rxnd.indices <- function() {
           checkTrue(is.na(expected[[i]]) && is.na(result$val[i]))
         }
 
-        checkEqualsNumeric(as.numeric(expected.val), as.numeric(result$val[i]), tolerance = 0.01)
+
         checkIdentical(as.character(expected[[i]]), result$ymd[i], paste("idx:", idx, "Expected: ", as.character(expected[[i]]), "result: ", as.character(result$ymd[i])))
+        checkEqualsNumeric(as.numeric(expected.val), as.numeric(result$val[i]), tolerance = 0.01)
       }
     }
   }

--- a/tests/test_exact_timing.R
+++ b/tests/test_exact_timing.R
@@ -162,7 +162,7 @@ get.spell.bounds <- function(ci, idx) {
     spell <- find.longest.consecutive.true(bool.array)
     dates <- ci@dates[ci@date.factors$annual == year]
     if (spell$duration > 0) {
-      spell.bounds <- data.frame(start = dates[spell$start], end = dates[spell$end], duration = ifelse(is.na(ci@namasks$annual$prec[year]), NA, spell$duration))
+      spell.bounds <- data.frame(start = format(dates[spell$start], "%Y-%m-%d"), end = format(dates[spell$end], "%Y-%m-%d"), duration = ifelse(is.na(ci@namasks$annual$prec[year]), NA, spell$duration))
     } else {
       spell.bounds <- data.frame(start = NA, end = NA, duration = 0)
     }

--- a/tests/test_exact_timing.R
+++ b/tests/test_exact_timing.R
@@ -67,7 +67,8 @@ climdex.pcic.test.exact.date.n.or.x.indices <- function() {
         expected.val <- data[ci.csv@dates %in% as.character(expected[[i]])]
         expected.val <- ifelse(length(expected.val) == 0, NA, expected.val)
         checkIdentical(as.character(expected[[i]]), result$ymd[i])
-        checkEqualsNumeric(as.numeric(expected.val), as.numeric(result$val[i]))
+        if(is.na(expected.val) || is.na(result$val[i])) next
+        checkEquals(as.numeric(expected.val), as.numeric(result$val[i]))
       }
     }
   }

--- a/tests/test_exact_timing.R
+++ b/tests/test_exact_timing.R
@@ -3,7 +3,6 @@ library(RUnit)
 
 # Setup
 wd <- "./"
-source("../../climdex.pcic/R/climdex.r")
 
 ClimVars.tmax <- file.path(wd, "1018935_MAX_TEMP.csv")
 ClimVars.tmin <- file.path(wd, "1018935_MIN_TEMP.csv")
@@ -81,7 +80,7 @@ get.Rxnday.result <- function(idx, ci.csv, freq = c("monthly", "annual", "season
   fun <- which.max
   if (as.numeric(substr(idx, 3, 3)) == 5) {
     data[is.na(data)] <- 0
-    prec.runsum <- running.mean(data, ndays)
+    prec.runsum <- climdex.pcic:::running.mean(data, ndays)
     prec.runsum[is.na(prec.runsum)] <- 0
 
     if (center.mean.on.last.day) {
@@ -384,8 +383,8 @@ expected.gsl <- function(ci, as.df) {
       gsl.factor.monthly <- factor(paste(years.gsl[inset], months[inset], sep = "-"))
       gsl.yearmonth.factor <- unlist(strsplit(levels(gsl.factor.monthly), "-"))[(0:(nlevels(gsl.factor.monthly) - 1)) * 2 + 1]
       gsl.temp.data <- ci@data$tavg[inset]
-      namask.gsl.monthly <- get.na.mask(gsl.temp.data, gsl.factor.monthly, ci@max.missing.days["annual"])
-      ci@namasks$annual$tavg <- get.na.mask(gsl.temp.data, gsl.factor, ci@max.missing.days["annual"]) * as.numeric(tapply(namask.gsl.monthly, gsl.yearmonth.factor, prod))
+      namask.gsl.monthly <- climdex.pcic:::get.na.mask(gsl.temp.data, gsl.factor.monthly, ci@max.missing.days["annual"])
+      ci@namasks$annual$tavg <- climdex.pcic:::get.na.mask(gsl.temp.data, gsl.factor, ci@max.missing.days["annual"]) * as.numeric(tapply(namask.gsl.monthly, gsl.yearmonth.factor, prod))
     }
 
     ex.r$sl <- ex.r$sl * ci@namasks$annual$tavg

--- a/tests/test_exact_timing.R
+++ b/tests/test_exact_timing.R
@@ -758,6 +758,55 @@ climdex.pcic.tests.exact.dates.are.in.factors <- function() {
 
 }
 
+
+checkTypes <- function(result.e.d.vals, result.n.d) {
+  for (i in seq_along(result.e.d.vals)){
+    checkIdentical(typeof(result.e.d.vals[i]),typeof(result.n.d[i]), paste("Different types: With exact dates:", typeof(result.e.d.vals[i]), "Without:", typeof(result.n.d[i])))
+  }
+  
+}
+climdex.pcic.test.consistent.indices.return.types <- function() {
+  
+  start_date <- as.PCICt("1961-01-01", cal = "365")
+  end_date <- as.PCICt("1967-12-30", cal = "365")
+  dates <- seq(start_date, end_date, by = "days")
+  
+  set.seed(123)
+  n <- length(dates)
+  tmax <- runif(n, -10, 35)
+  tmin <- runif(n, -15, 30)
+  prec <- runif(n, 0, 40)
+  
+  na_indices <- sample(1:n, size = round(n * 0.1))
+  tmax[na_indices] <- NA
+  tmin[na_indices] <- NA
+  prec[na_indices] <- NA
+  
+  # Create climdexInput object
+  ci.types.test <- climdexInput.raw(tmax = tmax, tmin = tmin, prec = prec, tmax.dates = dates, tmin.dates = dates, prec.dates = dates)
+  test.indices <- c("txx", "tnn", "tnx", "txn", "rx1day", "rx5day")
+  for(idx in test.indices){
+    fun <- paste("climdex", idx, sep = ".")
+    date.factors <- c("annual", "monthly", "seasonal")
+    for (freq in date.factors) {
+      result.e.d <- do.call(fun, list(ci.types.test, freq = freq, include.exact.dates = TRUE))
+      result.n.d <- do.call(fun, list(ci.types.test, freq = freq, include.exact.dates = FALSE))
+      checkTypes(result.e.d$val, result.n.d)
+    }
+  }
+
+  freq<- "annual"
+  result.e.d <- climdex.cdd(ci.types.test, spells.can.span.years = F, include.exact.dates = TRUE)
+  result.n.d <- climdex.cdd(ci.types.test, spells.can.span.years = F, include.exact.dates = F)
+  checkTypes(result.e.d$duration, result.n.d)
+  result.e.d <- climdex.cwd(ci.types.test, spells.can.span.years = F, include.exact.dates = TRUE)
+  result.n.d <- climdex.cwd(ci.types.test, spells.can.span.years = F, include.exact.dates = F)
+  checkTypes(result.e.d$duration, result.n.d)
+  result.e.d <- climdex.gsl(ci.types.test,"GSL", include.exact.dates = TRUE)
+  result.n.d <- climdex.gsl(ci.types.test,"GSL", include.exact.dates = F)
+  checkTypes(result.e.d$sl, result.n.d)
+}
+
 # climdex.pcic.test.indicies.on.random.datasets <- function(){
 #   for (i in 1:5000){
 #     cal <- 365

--- a/tests/test_exact_timing.R
+++ b/tests/test_exact_timing.R
@@ -31,11 +31,8 @@ expected.exact.date <- function(ci.csv, data, factor.extremes, date.factors, fre
 }
 
 get.data.for.idx <- function(ci, idx) {
-  if (substr(idx, 2, 2) == "x") {
-    ci@data$tmax
-  } else {
-    ci@data$tmin
-  }
+  var <- climdex.min.max.idx.list[[idx]]$var
+  ci@data[[var]]
 }
 
 are.not.all.na <- function(x,r) {
@@ -70,7 +67,7 @@ is.almost.equal <- function(x, r, tolerance = 0.01) {
 
 # Test for TXx, TNn, TNx and TXn indices.
 climdex.pcic.test.exact.date.n.or.x.indices <- function() {
-  test.indices <- c("txx", "tnn", "tnx", "txn")
+  test.indices <- names(climdex.min.max.idx.list)[grepl("t", names(climdex.min.max.idx.list))]
   date.factors <- c("annual", "monthly", "seasonal")
 
   for (idx in test.indices) {
@@ -99,7 +96,7 @@ climdex.pcic.test.exact.date.n.or.x.indices <- function() {
 # Boundary test that checks if TXx and TNn occur on the last day of the year,
 # and TXn and TNx occur on the first day of the year.
 climdex.pcic.test.n.or.x.dates.at.end.of.year <- function() {
-  test.indices <- c("txx", "tnn", "tnx", "txn")
+  test.indices <- names(climdex.min.max.idx.list)[grepl("t", names(climdex.min.max.idx.list))]
   date.factors <- c("annual", "monthly", "seasonal")
   cal <- 365
   test.dates <- seq(as.PCICt("1961-01-01", cal = cal), as.PCICt("1961-12-31", cal = cal), by = "days")
@@ -121,7 +118,7 @@ climdex.pcic.test.n.or.x.dates.at.end.of.year <- function() {
       for (i in seq_along(expected)) {
         expected.val <- data[ci.nx.eoy@dates == expected[[i]]]
         expected.val <- ifelse(length(expected.val) == 0, NA, expected.val)
-        checkIdentical(as.character(expected[[i]]), result$ymd[i], paste("idx:", idx, "Expected: ", as.character(expected[[i]]), "Result: ", as.character(result$ymd[i])))
+        checkIdentical(as.character(expected[[i]]), result$ymd[i], paste("Idx:", idx, "Expected: ", as.character(expected[[i]]), "Result: ", as.character(result$ymd[i])))
         checkTrue(is.almost.equal(as.numeric(expected.val), as.numeric(result$val[i])), 
                   msg = paste("Idx:", idx, "Expected: ", as.numeric(expected.val), "Result: ", as.numeric(result$val[i])))
       }
@@ -131,7 +128,7 @@ climdex.pcic.test.n.or.x.dates.at.end.of.year <- function() {
 
 # Check extreme dates in winter season.
 climdex.pcic.test.n.or.x.dates.for.winter.season <- function() {
-  test.indices <- c("txx", "tnn", "tnx", "txn")
+  test.indices <- names(climdex.min.max.idx.list)[grepl("t", names(climdex.min.max.idx.list))]
   cal <- 365
   test.dates <- seq(as.PCICt("1960-12-01", cal = cal), as.PCICt("1961-02-28", cal = cal), by = "days")
   
@@ -153,7 +150,7 @@ climdex.pcic.test.n.or.x.dates.for.winter.season <- function() {
     for (i in seq_along(expected)) {
       expected.val <- data[ci.nx.eoy@dates == expected[[i]]]
       expected.val <- ifelse(length(expected.val) == 0, NA, expected.val)
-      checkIdentical(as.character(expected[[i]]), result$ymd[i], paste("idx:", idx, "Expected:", as.character(expected[[i]]), "Result:", as.character(result$ymd[i])))
+      checkIdentical(as.character(expected[[i]]), result$ymd[i], paste("Idx:", idx, "Expected:", as.character(expected[[i]]), "Result:", as.character(result$ymd[i])))
       checkTrue(is.almost.equal(as.numeric(expected.val), as.numeric(result$val[i])),
                 msg = paste("Idx:", idx, "Expected:", as.numeric(expected.val), "Result:", as.numeric(result$val[i])))
     }
@@ -186,7 +183,7 @@ get.Rxnday.result <- function(idx, ci.csv, freq = c("monthly", "annual", "season
 
 # Test exact dates returned for Rx1day and Rx5day indices.
 climdex.pcic.test.exact.date.rxnd.indices <- function() {
-  test.indices <- c("rx1day", "rx5day")
+  test.indices <- names(climdex.min.max.idx.list)[grepl("r", names(climdex.min.max.idx.list))]
   date.factors <- c("annual", "monthly", "seasonal")
 
   for (idx in test.indices) {
@@ -215,7 +212,7 @@ climdex.pcic.test.exact.date.rxnd.indices <- function() {
         }
 
 
-        checkIdentical(as.character(expected[[i]]), result$ymd[i], paste("idx:", idx, "Expected: ", as.character(expected[[i]]), "Result: ", as.character(result$ymd[i])))
+        checkIdentical(as.character(expected[[i]]), result$ymd[i], paste("Idx:", idx, "Expected: ", as.character(expected[[i]]), "Result: ", as.character(result$ymd[i])))
         checkTrue(is.almost.equal(as.numeric(expected.val), as.numeric(result$val[i])), 
                   msg = paste("Idx:", idx, "Expected: ", as.numeric(expected.val), "Result: ", as.numeric(result$val[i])))
       }
@@ -740,7 +737,7 @@ check.duration.bounds.in.factors <- function(freq, result, spells.can.span.years
 
 # Test that the exact dates for all indices except for GSL have exact dates returned are in their associated date factor.
 climdex.pcic.tests.exact.dates.are.in.factors <- function() {
-  test.indices <- c("txx", "tnn", "tnx", "txn", "rx1day", "rx5day")
+  test.indices <- names(climdex.min.max.idx.list)
   for(idx in test.indices){
     fun <- paste("climdex", idx, sep = ".")
     date.factors <- c("annual", "monthly", "seasonal")
@@ -784,7 +781,7 @@ climdex.pcic.test.consistent.indices.return.types <- function() {
   
   # Create climdexInput object
   ci.types.test <- climdexInput.raw(tmax = tmax, tmin = tmin, prec = prec, tmax.dates = dates, tmin.dates = dates, prec.dates = dates)
-  test.indices <- c("txx", "tnn", "tnx", "txn", "rx1day", "rx5day")
+  test.indices <- names(climdex.min.max.idx.list)
   for(idx in test.indices){
     fun <- paste("climdex", idx, sep = ".")
     date.factors <- c("annual", "monthly", "seasonal")
@@ -806,7 +803,7 @@ climdex.pcic.test.consistent.indices.return.types <- function() {
   result.n.d <- climdex.gsl(ci.types.test,"GSL", include.exact.dates = F)
   checkTypes(result.e.d$sl, result.n.d)
 }
-
+# 
 # climdex.pcic.test.indicies.on.random.datasets <- function(){
 #   for (i in 1:5000){
 #     cal <- 365
@@ -814,7 +811,7 @@ climdex.pcic.test.consistent.indices.return.types <- function() {
 #     test.prec.ran <- c(sample(0:2, length(test.dates), replace = TRUE))
 #     test.tmin.ran <- c(sample(-10:32, length(test.dates), replace = TRUE))
 #     test.tmax.ran <- c(sample(-10:32, length(test.dates), replace = TRUE))
-#     
+# 
 # 
 #     years <- format(test.dates, "%Y")
 #     unique.years <- unique(years)
@@ -825,27 +822,27 @@ climdex.pcic.test.consistent.indices.return.types <- function() {
 #       test.tmin.ran[na.indices] <- NA
 #       test.tmax.ran[na.indices] <- NA
 #     }
-#     
-#     
+# 
+# 
 #     ci.ran <- climdexInput.raw(tmin =test.tmin.ran, tmax = test.tmax.ran, prec = test.prec.ran, tmin.dates=test.dates, tmax.dates = test.dates, prec.dates = test.dates)
-#     
-#     test.indices <- c("txx", "tnn", "tnx", "txn", "rx1day", "rx5day")
+# 
+#     test.indices <- names(climdex.min.max.idx.list)
 #     for(idx in test.indices){
 #       fun <- paste("climdex", idx, sep = ".")
 #       date.factors <- c("annual", "monthly", "seasonal")
 #       for (freq in date.factors) {
 #         do.call(fun, list(ci.ran, freq = freq, include.exact.dates = TRUE))
-#         
+# 
 #       }
 #     }
-#     
+# 
 #     freq<- "annual"
 #     climdex.cdd(ci.ran, spells.can.span.years = F, include.exact.dates = TRUE)
 #     climdex.cwd(ci.ran, spells.can.span.years = F, include.exact.dates = TRUE)
 #     climdex.gsl(ci.ran,"GSL", include.exact.dates = TRUE)
-#   } 
-#   
-#   
+#   }
+# 
+# 
 # }
 
 

--- a/tests/test_exact_timing.R
+++ b/tests/test_exact_timing.R
@@ -69,8 +69,10 @@ climdex.pcic.test.exact.date.n.or.x.indices <- function() {
       for (i in seq_along(expected)) {
         expected.val <- data[ci.csv@dates %in% as.character(expected[[i]])]
         expected.val <- ifelse(length(expected.val) == 0, NA, expected.val)
-        checkIdentical(as.character(expected[[i]]), as.character(result$ymd[i]), paste("idx:", idx, "Expected: ", as.character(expected[[i]]), "result: ", as.character(result$ymd[i])))
-        checkEqualsNumeric(as.numeric(expected.val), as.numeric(result$val[i]), tolerance = 0.01)
+        checkIdentical(as.character(expected[[i]]), as.character(result$ymd[i]), 
+                       paste("idx:", idx, "Expected: ", as.character(expected[[i]]), "result: ", as.character(result$ymd[i])))
+        checkTrue(all.equal(as.numeric(expected.val), as.numeric(result$val[i]), tolerance = 0.01), 
+                  msg = paste("idx:", idx, "Expected: ", as.character(expected.val), "result: ", as.character(result$val[i])))
       }
     }
   }
@@ -101,7 +103,8 @@ climdex.pcic.test.n.or.x.dates.at.end.of.year <- function() {
         expected.val <- data[ci.nx.eoy@dates %in% as.character(expected[[i]])]
         expected.val <- ifelse(length(expected.val) == 0, NA, expected.val)
         checkIdentical(as.character(expected[[i]]), result$ymd[i], paste("idx:", idx, "Expected: ", as.character(expected[[i]]), "result: ", as.character(result$ymd[i])))
-        checkEqualsNumeric(as.numeric(expected.val), as.numeric(result$val[i]), tolerance = 0.01)
+        checkTrue(all.equal(as.numeric(expected.val), as.numeric(result$val[i]), tolerance = 0.01), 
+                  msg = paste("idx:", idx, "Expected: ", as.character(expected.val), "result: ", as.character(result$val[i])))
       }
     }
   }
@@ -160,7 +163,8 @@ climdex.pcic.test.exact.date.rxnd.indices <- function() {
 
 
         checkIdentical(as.character(expected[[i]]), result$ymd[i], paste("idx:", idx, "Expected: ", as.character(expected[[i]]), "result: ", as.character(result$ymd[i])))
-        checkEqualsNumeric(as.numeric(expected.val), as.numeric(result$val[i]), tolerance = 0.01)
+        checkTrue(all.equal(as.numeric(expected.val), as.numeric(result$val[i]), tolerance = 0.01), 
+                  msg = paste("idx:", idx, "Expected: ", as.character(expected.val), "result: ", as.character(result$val[i])))
       }
     }
   }
@@ -414,7 +418,7 @@ expected.gsl <- function(ci, include.exact.dates) {
       end.result <- NA_character_
       duration <- 0
     } else if (is.na(end.idx)) {
-      end.result <- gsl.test.ymd(year, cal, length(tavg), n.h)
+      end.result <- gsl.test.ymd(year, cal, length(tavg)-1, n.h)
       duration <- length(tavg) + 1 - start.idx
     } else {
       end.result <- gsl.test.ymd(year, cal, (ifelse(end.idx > 1, midpoint + end.idx - 1, ifelse(!n.h && next.year.is.leap, midpoint, midpoint + 1))), n.h)

--- a/tests/test_exact_timing.R
+++ b/tests/test_exact_timing.R
@@ -1,0 +1,280 @@
+library(climdex.pcic)
+library(RUnit)
+
+# Setup
+
+wd <- "./"
+source("../../climdex.pcic/R/climdex.r")
+
+ClimVars.tmax <- file.path(wd, "1018935_MAX_TEMP.csv")
+ClimVars.tmin <- file.path(wd, "1018935_MIN_TEMP.csv")
+ClimVars.prec <- file.path(wd, "1018935_ONE_DAY_PRECIPITATION.csv")
+
+
+datacol <- list(tmax = "MAX_TEMP", tmin = "MIN_TEMP", prec = "ONE_DAY_PRECIPITATION")
+ci.csv <- climdexInput.csv(ClimVars.tmax, ClimVars.tmin, ClimVars.prec, data.columns = datacol, base.range = c(1981, 1990))
+ci.csv.sh <- climdexInput.csv(ClimVars.tmax, ClimVars.tmin, ClimVars.prec, data.columns = datacol, base.range = c(1981, 1990),northern.hemisphere = F)
+
+expected.result <- function(ci.csv, data, date.index, date.factors, freq, fun, offset, na.mask) {
+  ex.r <- c()
+  ex.r <- lapply(seq_along(date.factors), function(i) {
+    factor.name <- names(date.index[i])
+    dof <- date.index[[i]]
+    dates <- ci.csv@dates[ci.csv@date.factors[[freq]] == factor.name]
+    if (!is.na(na.mask[i])) {
+      dates[dof]
+    } else {
+      NA
+    }
+  })
+  return((ex.r))
+}
+
+
+get.n.or.x.result <- function(idx, ci.csv, freq = c("monthly", "annual", "seasonal")) {
+  data <- if (substr(idx, 2, 2) == "x") {
+    ci.csv@data$tmax
+  } else {
+    ci.csv@data$tmin
+  }
+  na.mask <- if (substr(idx, 2, 2) == "x") {
+    ci.csv@namasks[[freq]]$tmax
+  } else {
+    ci.csv@namasks[[freq]]$tmin
+  }
+  fun <- ifelse(substr(idx, 3, 3) == "x", which.max, which.min)
+  offset <- 0
+  date.index <- tapply(data, ci.csv@date.factors[[match.arg(freq)]], function(x) fun(x))
+  date.factors <- unique(ci.csv@date.factors[[match.arg(freq)]])
+  return(expected.result(ci.csv, data, date.index, date.factors, freq, fun, offset, na.mask))
+}
+
+# Exact date:
+climdex.pcic.test.exact.date.n.or.x.indices <- function() {
+  test.indices <- c("txx", "tnn", "tnx", "txn")
+  date.factors <- c("annual", "monthly", "seasonal")
+  
+  for (idx in test.indices) {
+    data <- if (substr(idx, 2, 2) == "x") {
+      ci.csv@data$tmax
+    } else {
+      ci.csv@data$tmin
+    }
+    
+    for (freq in date.factors) {
+      print(paste(idx, freq))
+      fun <- paste("climdex", idx, sep = ".")
+      result <- do.call(fun, list(ci.csv, freq = freq, as.df = TRUE))
+      expected <- get.n.or.x.result(idx, ci.csv, freq)
+      result$ymd <- as.character(result$ymd)
+      for (i in seq_along(expected)) {
+        expected.val <- data[ci.csv@dates %in% as.character(expected[[i]])]
+        expected.val <- ifelse(length(expected.val) == 0, NA, expected.val)
+        checkIdentical(as.character(expected[[i]]), result$ymd[i])
+        checkEqualsNumeric(as.numeric(expected.val), as.numeric(result$val[i]))
+      }
+    }
+  }
+}
+
+
+get.Rxnday.result <- function(idx, ci.csv, freq = c("monthly", "annual", "seasonal"), ndays, center.mean.on.last.day) {
+  data <- ci.csv@data$prec
+  na.mask <- ci.csv@namasks[[freq]]$prec
+  fun <- which.max
+  if (as.numeric(substr(idx, 3, 3)) == 5) {
+    data[is.na(data)] <- 0
+    prec.runsum <- running.mean(data, ndays)
+    prec.runsum[is.na(prec.runsum)] <- 0
+    
+    if (center.mean.on.last.day) {
+      k2 <- ndays %/% 2
+      prec.runsum <- c(rep(0, k2), prec.runsum[1:(length(prec.runsum) - k2)])
+    }
+    data <- prec.runsum
+  }
+  date.index <- tapply(data, ci.csv@date.factors[[match.arg(freq)]], function(x) fun(x))
+  date.factors <- unique(ci.csv@date.factors[[match.arg(freq)]])
+  return(expected.result(ci.csv, data, date.index, date.factors, freq, fun, offset, na.mask))
+}
+
+
+climdex.pcic.test.exact.date.rxnd.indices <- function() {
+  test.indices <- c("rx1day", "rx5day")
+  date.factors <- c("annual", "monthly", "seasonal")
+  
+  for (idx in test.indices) {
+    for (freq in date.factors) {
+      print(paste(idx, freq))
+      fun <- paste("climdex", idx, sep = ".")
+      result <- do.call(fun, list(ci.csv, freq = freq, as.df = TRUE))
+      ndays <- as.numeric(substr(idx, 3, 3))
+      center.mean.on.last.day <- FALSE
+      expected <- get.Rxnday.result(idx, ci.csv, freq, ndays, center.mean.on.last.day)
+      result$ymd <- as.character(result$ymd)
+      
+      for (i in seq_along(result$ymd)) {
+        if (!is.na(result$ymd[i])) {
+          if (ndays == 5) {
+            window.start <- expected[[i]] - 2 * 86400
+            window.end <- expected[[i]] + 2 * 86400
+            expected.value <- sum(ci.csv@data$prec[ci.csv@dates >= window.start & ci.csv@dates <= window.end], na.rm = TRUE)
+          } else {
+            expected.value <- ci.csv@data$prec[ci.csv@dates == expected[[i]]]
+          }
+        } else {
+          expected.value <- NA
+          checkTrue(is.na(expected[[i]]) && is.na(result$val[i]))
+        }
+        checkEqualsNumeric(as.numeric(expected.value), as.numeric(result$val[i]), tolerance = 0.01)
+        checkIdentical(as.character(expected[[i]]), result$ymd[i])
+      }
+    }
+  }
+}
+
+find.longest.consecutive.true <- function(bool.array) {
+  max.length <- current.length <- start.index <- max.start.index <- 0
+  
+  for (i in seq_along(bool.array)) {
+    if (!is.na(bool.array[i]) && bool.array[i]) {
+      current.length <- current.length + 1
+      if (current.length == 1) start.index <- i
+      if (start.index) {
+        if (current.length > max.length) {
+          max.length <- current.length
+          max.start.index <- start.index
+        }
+      }
+    } else {
+      start.index <- current.length <- 0
+    }
+  }
+  
+  data.frame(start = max.start.index, end = max.start.index + max.length - 1, duration = max.length)
+}
+
+
+get.spell.bounds <- function(ci, idx) {
+  spell.boundary <- lapply(unique(ci@date.factors$annual), function(year) {
+    if (idx == "cdd") {
+      bool.array <- ci@data$prec[ci@date.factors$annual == year] < 1
+    } else {
+      bool.array <- ci@data$prec[ci@date.factors$annual == year] >= 1
+    }
+    spell <- find.longest.consecutive.true(bool.array)
+    dates <- ci@dates[ci@date.factors$annual == year]
+    if (spell$duration > 0) {
+      spell.bounds <- data.frame(start = dates[spell$start], end = dates[spell$end], duration = ifelse(is.na(ci@namasks$annual$prec[year]), NA, spell$duration))
+    } else {
+      spell.bounds <- data.frame(start = NA, end = NA, duration = 0)
+    }
+    
+    return(spell.bounds)
+  })
+  return(spell.boundary)
+}
+
+check.spell.results <- function(expected, result, idx) {
+  for (i in seq_along(result$start)) {
+    if (is.na(expected[[i]]$duration)) {
+      expected[[i]]$start <- NA
+      expected[[i]]$end <- NA
+    }
+    checkIdentical(as.character(expected[[i]]$start), result$start[i], paste("Start of spells for index: ", idx, " do not agree: Expected:", as.character(expected[[i]]$start), " Result: ", result$start[i]))
+    checkIdentical(as.character(expected[[i]]$end), result$end[i])
+  }
+}
+
+
+climdex.pcic.test.spell.boundaries <- function() {
+  test.indices <- c("cdd", "cwd")
+  for (idx in test.indices) {
+    print(paste(idx))
+    
+    if (idx == "cdd") {
+      result <- climdex.cdd(ci.csv, spells.can.span.years = F, as.df = TRUE)
+    } else {
+      result <- climdex.cwd(ci.csv, spells.can.span.years = F, as.df = TRUE)
+    }
+    
+    expected <- get.spell.bounds(ci.csv, idx)
+    check.spell.results(expected, result, idx)
+  }
+}
+
+
+climdex.pcic.test.multi.year.spell <- function() {
+  cal <- 365
+  test.dates <- seq(as.PCICt("1961-01-01", cal = cal), as.PCICt("1967-12-31", cal = cal), by = "days")
+
+  test.prec.data.dry <- rep(0, length(test.dates))
+  ci.dry <- climdexInput.raw(prec = test.prec.data.dry, prec.dates = test.dates)
+  
+  test.prec.data.wet <- rep(2, length(test.dates))
+  ci.wet <- climdexInput.raw(prec = test.prec.data.wet, prec.dates = test.dates)
+  
+  test.indices <- c("cdd", "cwd")
+  for (idx in test.indices) {
+    print(paste(idx))
+    
+    if (idx == "cdd") {
+      result <- climdex.cdd(ci.dry, spells.can.span.years = F, as.df = TRUE)
+      ci <- ci.dry
+    } else {
+      result <- climdex.cwd(ci.wet, spells.can.span.years = F, as.df = TRUE)
+      ci <- ci.wet
+    }
+    
+    expected <- get.spell.bounds(ci, idx)
+    check.spell.results(expected, result, idx)
+  }
+}
+
+climdex.pcic.test.no.spell <- function() {
+  cal <- 365
+  test.dates <- seq(as.PCICt("1961-01-01", cal = cal), as.PCICt("1967-12-31", cal = cal), by = "days")
+  test.prec.data.dry <- rep(0, length(test.dates))
+  test.prec.data.wet <- rep(1, length(test.dates))
+  
+  ci.wet <- climdexInput.raw(prec = test.prec.data.wet, prec.dates = test.dates)
+  ci.dry <- climdexInput.raw(prec = test.prec.data.dry, prec.dates = test.dates)
+  
+  test.indices <- c("cdd", "cwd")
+  for (idx in test.indices) {
+    print(paste(idx))
+    
+    if (idx == "cdd") {
+      result <- climdex.cdd(ci.wet, spells.can.span.years = F, as.df = TRUE)
+      ci <- ci.wet
+    } else {
+      result <- climdex.cwd(ci.dry, spells.can.span.years = F, as.df = TRUE)
+      ci <- ci.dry
+    }
+    
+    expected <- get.spell.bounds(ci, idx)
+    check.spell.results(expected, result, idx)
+  }
+}
+
+climdex.pcic.test.na.masks.spell <- function() {
+  cal <- 365
+  test.dates <- seq(as.PCICt("1961-01-01", cal = cal), as.PCICt("1967-12-31", cal = cal), by = "days")
+  test.dates.factor <- factor(format(test.dates, "%Y"))
+  test.prec.data.ran <- c(sample(0:2, length(test.dates), replace = TRUE))
+  ci.ran <- climdexInput.raw(prec = test.prec.data.ran, prec.dates = test.dates)
+  ci.ran@namasks$annual$prec <- rep(c(NA, 1), length.out = length(unique(test.dates.factor)))
+  
+  test.indices <- c("cdd", "cwd")
+  for (idx in test.indices) {
+    print(paste(idx))
+    
+    if (idx == "cdd") {
+      result <- climdex.cdd(ci.ran, spells.can.span.years = F, as.df = TRUE)
+    } else {
+      result <- climdex.cwd(ci.ran, spells.can.span.years = F, as.df = TRUE)
+    }
+    expected <- get.spell.bounds(ci.ran, idx)
+    check.spell.results(expected, result, idx)
+  }
+}

--- a/tests/test_exact_timing.R
+++ b/tests/test_exact_timing.R
@@ -302,8 +302,10 @@ get.spell.bounds <- function(ci, idx) {
 
     return(spell.bounds)
   })
+
   return(do.call(rbind, spell.boundary))
 }
+
 # Generic to compare the expected and climdex-calculated results for the spell tests.
 check.spell.results <- function(expected, result, idx) {
   checkIdentical(nrow(expected), nrow(result), paste("Lengths Differ. Expected:", nrow(expected), "Result:", nrow(result)))
@@ -316,7 +318,7 @@ check.spell.results <- function(expected, result, idx) {
     checkIdentical(as.character(expected$start[i]), result$start[i], paste("Start of spells for index:", idx, "do not agree. Expected:", as.character(expected$start[i]), "Result:", result$start[i]))
     checkIdentical(as.character(expected$end[i]), result$end[i], paste("End of spells for index:", idx, "do not agree. Expected:", as.character(expected$end[i]), "Result:", result$end[i]))
     checkTrue(is.almost.equal(as.numeric(expected$duration[i]), as.numeric(result$duration[i])), 
-              msg = paste("Idx:", idx, "Expected:", as.numeric(expected$duration[i]), "Result:", as.numeric(result$duration[i])))
+              msg = paste("Idx:", idx, "Expected:",as.character(expected$start[i]), as.numeric(expected$duration[i]), as.character(expected$end[i]), "Result:", result$start[i], as.numeric(result$duration[i]), result$end[i]))
   }
 }
 
@@ -443,6 +445,33 @@ climdex.pcic.test.na.masks.spell <- function() {
   }
 }
 
+climdex.pcic.test.spells.can.span.years <- function() {
+  test.indices <- c("cdd", "cwd")
+  cal <- 365
+  test.dates <- seq(as.PCICt("1961-01-01", cal = cal), as.PCICt("1962-12-31", cal = cal), by = "days")
+
+  for (idx in test.indices) {
+    if (idx == "cdd") {
+      test.prec.data <- rep(2, length(test.dates))
+      test.prec.data[(cal - 20):(cal - 10)] <- 0
+      test.prec.data[(cal - 1):(cal + 4)] <- 0
+      ci <- climdexInput.raw(prec = test.prec.data, prec.dates = test.dates)
+
+      expected <- data.frame(start <- c("1961-12-11", "1961-12-30"), duration <- c(11, 6), end <- c("1961-12-21", "1962-01-04"))
+      result <- climdex.cdd(ci, spells.can.span.years = TRUE, include.exact.dates = TRUE)
+    } else {
+      test.prec.data <- rep(0, length(test.dates))
+      test.prec.data[(cal - 20):(cal - 10)] <- 2
+      test.prec.data[(cal - 1):(cal + 4)] <- 2
+
+      ci <- climdexInput.raw(prec = test.prec.data, prec.dates = test.dates)
+
+      expected <- data.frame(start <- c("1961-12-11", "1961-12-30"), duration <- c(11, 6), end <- c("1961-12-21", "1962-01-04"))
+      result <- climdex.cwd(ci, spells.can.span.years = TRUE, include.exact.dates = TRUE)
+    }
+    check.spell.results(expected, result, idx)
+  }
+}
 # Return start or end of the GSL index as PCICt object in %Y-%m-%d format
 gsl.test.ymd <- function(year, cal, doy, northern.hemisphere) {
   origin <- ifelse(northern.hemisphere, paste(year, "01", "01", sep = "-"), paste(year, "07", "01", sep = "-"))
@@ -673,9 +702,7 @@ check.duration.bounds.in.factors <- function(freq, result, spells.can.span.years
 
 
 climdex.pcic.tests.exact.dates.are.in.factors <- function() {
-  
   test.indices <- c("txx", "tnn", "tnx", "txn", "rx1day", "rx5day")
-  
   for(idx in test.indices){
     fun <- paste("climdex", idx, sep = ".")
     date.factors <- c("annual", "monthly", "seasonal")

--- a/tests/test_seasonal_date_factor.R
+++ b/tests/test_seasonal_date_factor.R
@@ -33,7 +33,6 @@ climdex.pcic.test.seasonal.na.cases <- function() {
 
   # Create climdexInput object
   ci.na.test <- climdexInput.raw(tmax = tmax, tmin = tmin, prec = prec, tmax.dates = dates, tmin.dates = dates, prec.dates = dates)
-  ci.na.test
   
   var.list <- c("tmax", "tmin", "prec", "tavg")
   for (var in var.list) {

--- a/tests/test_seasonal_date_factor.R
+++ b/tests/test_seasonal_date_factor.R
@@ -77,7 +77,7 @@ climdex.pcic.test.seasonal.na.cases <- function() {
 # Test Seasonal Indices:
 # This section handles various scenarios based on the type of index being calculated:
 # - For non-averaged stats (e.g., min, max), the seasonal value is the min/max of the constituent months.
-# - For averaged stats, the seasonal value may differ from the average of the 3 constituent months due to varying month lengths, so it's compared against a calculated dtr (daily temperature range).
+# - For averaged stats, the seasonal value may differ from the average of the 3 constituent months due to varying month lengths, so it's compared against a calculated average dtr (diurnal temperature range).
 # - For percentile calculations, each season's percentile is computed against a weighted monthly percentile.
 
 ci_subset <- function(ci.csv, dates, season) {


### PR DESCRIPTION
### Description:
This pull request adds a new feature making it possible to return the exact date or date range in addition to the current return value of climate indices. The exact date is “localized” to a specific date factor which groups times series data into annual, monthly, or meteorological seasons buckets. Returning the exact timing is **optional**, and a data frame including the dates as additional attributes is returned when an `include.exact.dates` boolean parameter is set to `True`.


#### Indices with the new feature include:
- TXx, TXn, TNx, TNn
- Rx1day, Rx5day
- CDD, CWD
- GSL
##

### Changes:
- Modified `tapply.fast` to handle specific cases for which.min and which.max to handle missing values.
- Introduced a generic compute.stat function to compute statistics (min, max) for various climate indices: `climdex.txx`, `climdex.tnx`, `climdex.txn`, `climdex.tnn`, etc.
- Introduced a generic function `get.rxnday.params` to reduce repetition between Rx1day and Rx5day indices.
- Added utility functions ymd. dates and exact.date used to extract the dates of indices with single-date extremes and returns results as a data frame.
- Added an `include.exact.dates` parameter to several functions, allowing users to choose whether to return results as data frames.
- Updated `@param` tags to include the new function parameters for Roxygen-style documentation.
- Added a test suite to check that all indices with an associated exact date are returning the correct day, and that spell indices and the growing season length are returning a data frame with the start date, spell length, and end date.
 ##
### Testing and Verification:
- The changes to the package are passing R CMD Checks on the latest Ubuntu install for development, release, and the previous release versions of R.
- A new test suite `test_exact_timing` has been added, including testing for the exact dates or date ranges of the indices mentioned above (TXn,…, Rx1day,...,GSL).
- The tests validate the exact date output for a sample dataset `ec.1918935` and test-specifically contrived data.
- The expected results used for comparison are independently calculated with minimal reliance on package functions. The exceptions are `get.na.mask()` and `running.mean()`, which were not modified during this update.
- Edge cases included are wet and dry spells and growing season lengths that do not start, extend multiple years, and have appropriately applied NA masks to the results.
##

### Questions for Reviewer:
- Are there compatibility considerations I’ve missed? 
- Are there any other tests you would like to see? 
